### PR TITLE
Run test case test_tpm2_save_load_state_3 on Fedora on different archs

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -5,7 +5,7 @@ RUN dnf -y update \
  && git clone https://github.com/stefanberger/libtpms.git \
  && dnf -y install which expect libtasn1-devel socat tpm-tools trousers \
     python3 python3-twisted python3-cryptography python3-pip python3-setuptools \
-    gnutls-devel gnutls-utils net-tools libseccomp-devel softhsm \
+    gnutls-devel gnutls-utils net-tools libseccomp-devel softhsm tss2 \
  && git clone https://github.com/stefanberger/swtpm.git
 
 ARG LIBTPMS_BRANCH=master
@@ -25,7 +25,7 @@ RUN cd swtpm \
  && git checkout ${SWTPM_BRANCH} \
  && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl --disable-dependency-tracking \
  && make -j$(nproc) V=1 \
- && make -j$(nproc) V=1 VERBOSE=1 check \
+ && SWTPM_TEST_IBMTSS2=1 make -j$(nproc) V=1 VERBOSE=1 check \
  && make -j$(nproc) install
 
 RUN mkdir -p /tmp/myvtpm1.2 && mkdir -p /tmp/myvtpm2


### PR DESCRIPTION
Run the test case test_tpm2_save_load_state_3 that revelead a UBSAN
realted issue on Fedora on different archs. It needs the IBM TSS2
stack.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>