### PR TITLE
Fedora: Use older images for ppc64le and s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=master       --build-arg SWTPM_BRANCH=master       -f ${DOCKERFILE} . || travis_terminate 1; fi
   - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.7.0 --build-arg SWTPM_BRANCH=stable-0.5   -f ${DOCKERFILE} . || travis_terminate 1; fi
   - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.7.0 --build-arg SWTPM_BRANCH=stable-0.4   -f ${DOCKERFILE} . || travis_terminate 1; fi
-  - if [ -n "$IMG" ]; then docker run --name test --privileged --env LIBTPMS_BRANCH=master       --env SWTPM_BRANCH=master     -v ${PWD}:/test ${IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
+  - if [ -n "$IMG" ]; then docker run --name test --privileged --env LIBTPMS_BRANCH=master       --env SWTPM_BRANCH=master     -v ${PWD}:/test ${IMG}:${IMG_VERSION:-latest} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
   - if [ -n "$IMG" ]; then docker commit test snapshot; docker rm test; export NEW_IMG="snapshot"; fi
   - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.7.0 --env SWTPM_BRANCH=stable-0.5 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
   - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.7.0 --env SWTPM_BRANCH=stable-0.4 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
@@ -41,8 +41,8 @@ matrix:
 
   - os: linux
     arch: ppc64le
-    env: IMG=fedora
+    env: IMG=fedora IMG_VERSION=33
 
   - os: linux
     arch: s390x
-    env: IMG=fedora
+    env: IMG=fedora IMG_VERSION=33


### PR DESCRIPTION
On s390x we have this problem that I could not resolve with CONFIG_SHELL=/bin/bash
and M$=/usr/bib/m4. So, use an older version of Fedora.

/usr/bin/autoconf: This script requires a shell more modern than all
/usr/bin/autoconf: the shells that I found on your system.
/usr/bin/autoconf: Please tell bug-autoconf@gnu.org about your system,
/usr/bin/autoconf: including any error possibly output before this
/usr/bin/autoconf: message. Then install a modern shell, or manually run
/usr/bin/autoconf: the script under such a shell if you do have one.
autoreconf: /usr/bin/autoconf failed with exit status: 1

On ppc64le no Fedora image for this architecture seems to be available:

docker: no matching manifest for linux/ppc64le in the manifest list entries.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>