### PR TITLE
Make the build on Alpine work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: focal
 services:
   - docker
 language: c

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -14,7 +14,7 @@ RUN cd libtpms \
  && echo ${DATE} > /.date \
  && git pull \
  && git checkout ${LIBTPMS_BRANCH} \
- && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 --disable-dependency-tracking \
+ && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 \
  && make -j$(nproc) V=1 \
  && make -j$(nproc) V=1 check \
  && make install
@@ -23,7 +23,7 @@ ARG SWTPM_BRANCH=master
 RUN cd swtpm \
  && git pull \
  && git checkout ${SWTPM_BRANCH} \
- && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl --disable-dependency-tracking \
+ && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl \
  && make -j$(nproc) V=1 \
  && make -j$(nproc) V=1 VERBOSE=1 check \
  && make -j$(nproc) install

--- a/Dockerfile.centos-8
+++ b/Dockerfile.centos-8
@@ -14,7 +14,7 @@ RUN cd libtpms \
  && echo ${DATE} > /.date \
  && git pull \
  && git checkout ${LIBTPMS_BRANCH} \
- && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 --disable-dependency-tracking \
+ && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 \
  && make -j$(nproc) V=1 \
  && make -j$(nproc) V=1 check \
  && make install
@@ -23,7 +23,7 @@ ARG SWTPM_BRANCH=master
 RUN cd swtpm \
  && git pull \
  && git checkout ${SWTPM_BRANCH} \
- && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl --disable-dependency-tracking \
+ && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl \
  && make -j$(nproc) V=1 \
  && make -j$(nproc) V=1 VERBOSE=1 check \
  && make -j$(nproc) install

--- a/test.fedora
+++ b/test.fedora
@@ -20,7 +20,7 @@ pushd libtpms \
  && echo ${DATE} > /.date \
  && git pull \
  && git checkout ${LIBTPMS_BRANCH} \
- && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 --disable-dependency-tracking \
+ && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --with-openssl --with-tpm2 \
  && make -j$(nproc) V=1 \
  && make -j$(nproc) V=1 check \
  && make install \
@@ -31,7 +31,7 @@ SWTPM_BRANCH=${SWTPM_BRANCH:-master}
 pushd swtpm \
  && git pull \
  && git checkout ${SWTPM_BRANCH} \
- && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl --disable-dependency-tracking \
+ && ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --with-openssl \
  && make -j$(nproc) V=1 \
  && SWTPM_TEST_IBMTSS2=1 make -j$(nproc) V=1 VERBOSE=1 check \
  && make -j$(nproc) install \


### PR DESCRIPTION
Move to Focal as the host to get the Alpine container to build again. I don't know why the host OS version matters, but it now builds again. Also remove the --disable-dependency-tracking option from other builds since those aren't be necessary anymore.