### PR TITLE
Alpine: Disable pkcs11 tests due to crashes related to softhsm

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -25,7 +25,7 @@ RUN cd swtpm \
  && ./autogen.sh --prefix=/usr --libdir=/usr/lib --with-openssl --with-tss-user=root --with-tss-group=root \
  && make -j$(nproc) V=1 \
  && echo "softhsm or certtool are crashing pkcs11 test case" \
- && echo "#!/usr/bin/env bash" > tests/test_tpm2_samples_swtpm_localca_pkcs11 \
+ && { for f in test_tpm2_swtpm_localca_pkcs11.test test_tpm2_samples_swtpm_localca_pkcs11; do echo -en '#!/usr/bin/env bash'"\nexit 77\n" > tests/${f}; done; } \
  && make -j$(nproc) V=1 VERBOSE=1 check \
  && make -j$(nproc) install
 


### PR DESCRIPTION
Disable the pkcs11 tests since swtpm_cert ends up crashing due to
some issue related to softhsm.

Starting program: /usr/bin/swtpm_cert --subject CN=test \
 --tpm-manufacturer IBM --tpm-model swtpm-libtpms --tpm-version 2 \
 --platform-manufacturer Fedora --platform-version 2.1 \
 --platform-model QEMU --tpm2 --allow-signing --tpm-spec-family 2.0 \
 --tpm-spec-revision 146 --tpm-spec-level 0 \
 --out-cert /tmp/tmp.iCNfNB/ek.cert \
 --modulus 800102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff \
 --signkey pkcs11:model=SoftHSM%20v2\;manufacturer=SoftHSM%20project\;serial=de0b41f102dc3dcd\;token=swtpm-test\;id=%7D%03%0B%B9%4C%10%F3%EB%52%EA%92%97%2C%E0%22%13%75%D6%12%A7\;object=mykey\;type=public\?pin-value=abcdef\&module-name=softhsm2 \
 --issuercert /tmp/tmp.iCNfNB/issuercert.pem \
 --days -1 --serial 4
warning: Error disabling address space randomization: Operation not permitted

Program received signal SIGSEGV, Segmentation fault.
0x00007fd5d3b2d6d7 in memset () from /lib/ld-musl-x86_64.so.1
(gdb) bt

 #0  0x00007fd5d3b2d6d7 in memset () from /lib/ld-musl-x86_64.so.1
 #1  0x00007fd5d32b692c in Botan::deallocate_memory(void*, unsigned long, unsigned long) () from /usr/lib/libbotan-2.so.17
 #2  0x00007fd5d34f11d7 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #3  0x00007fd5d3506bf3 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #4  0x00007fd5d34ef164 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #5  0x00007fd5d350b21b in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #6  0x00007fd5d350b278 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #7  0x00007fd5d35233f9 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #8  0x00007fd5d352341a in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #9  0x00007fd5d35231a6 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #10 0x00007fd5d3522a52 in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #11 0x00007fd5d3522a9e in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #12 0x00007fd5d34d5e5b in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #13 0x00007fd5d34d5eee in ?? () from /usr/lib/softhsm/libsofthsm2.so
 #14 0x00007fd5d3af90c9 in ?? () from /lib/ld-musl-x86_64.so.1
 #15 0x000055942d6ed267 in capabilities_print_json () at ek-cert.c:992
 #16 0x0000000000000023 in ?? ()
 #17 0x00007fff196d2178 in ?? ()
 #18 0x00007fd5d3af107d in exit () from /lib/ld-musl-x86_64.so.1
 #19 0x00007fff196d2298 in ?? ()
 #20 0x000000002d6ed267 in ?? ()
 #21 0x0000000000000023 in ?? ()
 #22 0x00007fd5d3af8a0a in ?? () from /lib/ld-musl-x86_64.so.1
 #23 0x00007fd5d3af89dc in ?? () from /lib/ld-musl-x86_64.so.1
 #24 0x00007fff196d2170 in ?? ()
 #25 0x0000000000000000 in ?? ()

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>