### PR TITLE
centos: Add --nobest to dnf update to fix current issues

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -5,7 +5,7 @@ RUN rpm -e --nodeps centos-linux-repos \
      http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-4.el8.noarch.rpm \
      http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-4.el8.noarch.rpm
 
-RUN dnf -y update \
+RUN dnf -y --nobest update \
  && dnf -y install diffutils make file automake autoconf libtool gcc gcc-c++ openssl-devel gawk git \
  && git clone https://github.com/stefanberger/libtpms.git \
  && dnf -y install which python3 python3-cryptography python3-pip python3-setuptools expect libtasn1-devel \

--- a/Dockerfile.centos-8
+++ b/Dockerfile.centos-8
@@ -5,7 +5,7 @@ RUN rpm -e --nodeps centos-linux-repos \
     http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-4.el8.noarch.rpm \
     http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-4.el8.noarch.rpm
 
-RUN dnf -y update \
+RUN dnf -y --nobest update \
  && dnf -y install diffutils make file automake autoconf libtool gcc gcc-c++ openssl-devel gawk git \
  && git clone https://github.com/stefanberger/libtpms.git \
  && dnf -y install which python3 python3-cryptography python3-pip python3-setuptools expect libtasn1-devel \


### PR DESCRIPTION
add --nobest to dnf update to fix the following issue:
CentOS Stream 8 - AppStream                      62 MB/s |  21 MB     00:00
CentOS Stream 8 - BaseOS                         32 MB/s |  20 MB     00:00
CentOS Stream 8 - Extras                         56 kB/s |  18 kB     00:00
Last metadata expiration check: 0:00:01 ago on Mon Mar 28 15:43:55 2022.
Error:
 Problem: package centos-stream-repos-8-4.el8.noarch requires centos-gpg-keys = 1:8-4.el8, but none of the providers can be installed
  - cannot install both centos-gpg-keys-1:8-5.el8.noarch and centos-gpg-keys-1:8-4.el8.noarch
  - cannot install the best update candidate for package centos-stream-repos-8-4.el8.noarch
  - cannot install the best update candidate for package centos-gpg-keys-1:8-4.el8.noarch
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>