### PR TITLE
Travis: Build more recent version to avoid OSSL 3 compilation failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ language: c
 
 script:
   - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=master       --build-arg SWTPM_BRANCH=master       -f ${DOCKERFILE} . || travis_terminate 1; fi
+  - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.9   --build-arg SWTPM_BRANCH=stable-0.7   -f ${DOCKERFILE} . || travis_terminate 1; fi
   - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.8   --build-arg SWTPM_BRANCH=stable-0.6   -f ${DOCKERFILE} . || travis_terminate 1; fi
-  - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.8   --build-arg SWTPM_BRANCH=stable-0.5   -f ${DOCKERFILE} . || travis_terminate 1; fi
-  - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.7.0 --build-arg SWTPM_BRANCH=stable-0.4   -f ${DOCKERFILE} . || travis_terminate 1; fi
+  - if [ -z "$IMG" ]; then docker build --build-arg LIBTPMS_BRANCH=stable-0.7.0 --build-arg SWTPM_BRANCH=stable-0.5   -f ${DOCKERFILE} . || travis_terminate 1; fi
   - if [ -n "$IMG" ]; then docker run --name test --privileged --env LIBTPMS_BRANCH=master       --env SWTPM_BRANCH=master     -v ${PWD}:/test ${IMG}:${IMG_VERSION:-latest} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
   - if [ -n "$IMG" ]; then docker commit test snapshot; docker rm test; export NEW_IMG="snapshot"; fi
-  - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.8   --env SWTPM_BRANCH=stable-0.5 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
+  - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.9   --env SWTPM_BRANCH=stable-0.7 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
   - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.8   --env SWTPM_BRANCH=stable-0.6 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
-  - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.7.0 --env SWTPM_BRANCH=stable-0.4 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
+  - if [ -n "$IMG" ]; then docker run             --privileged --env LIBTPMS_BRANCH=stable-0.7.0 --env SWTPM_BRANCH=stable-0.5 -v ${PWD}:/test ${NEW_IMG} /test/test.$(echo $IMG | tr "/" "-") || travis_terminate 1; fi
 
 matrix:
   include:


### PR DESCRIPTION
Build more recent versions of libtpms and swtpm also to avoid OpenSSL 3.0
compilation failures due to -Werror being used.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>