### PR TITLE
Fix issue with file collision on SuSE Tumbleweed

### DIFF
--- a/test.opensuse-tumbleweed
+++ b/test.opensuse-tumbleweed
@@ -3,7 +3,7 @@
 
 zypper ref && zypper dup -y \
  && zypper install -y diff automake autoconf libtool gcc gcc-c++ make openssl-devel pkg-config git \
- && zypper install -y which python3-Twisted python3-cryptography python3-pip python3-setuptools \
+ && zypper install -y python3-Twisted python3-cryptography python3-pip python3-setuptools \
     expect socat net-tools-deprecated libtasn1-devel gnutls-devel libseccomp-devel tpm-tools trousers softhsm \
     gnutls json-glib-devel \
  && zypper install -y system-user-tss


### PR DESCRIPTION
Fix the following package installation issue:

Problem: the installed busybox-which-1.35.0-23.4.noarch conflicts with 'which' provided by the to be installed which-2.21-5.5.x86_64
 Solution 1: deinstallation of busybox-which-1.35.0-23.4.noarch
 Solution 2: do not install which-2.21-5.5.x86_64

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>